### PR TITLE
Make coredump-builder no_std

### DIFF
--- a/lib/coredump-builder/src/lib.rs
+++ b/lib/coredump-builder/src/lib.rs
@@ -23,8 +23,14 @@
 //! ```
 //!
 //! [Wasm Coredump]: https://github.com/WebAssembly/tool-conventions/blob/main/Coredump.md
+#![cfg_attr(not(test), no_std)]
 
-type BoxError = Box<dyn std::error::Error + Sync + Send>;
+extern crate alloc;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::Infallible;
 
 #[cfg(test)]
 mod test;
@@ -117,7 +123,7 @@ impl CoredumpBuilder {
     }
 
     /// Serialize the coredump to bytes, using the Wasm binary format.
-    pub fn serialize(self) -> Result<Vec<u8>, BoxError> {
+    pub fn serialize(self) -> Result<Vec<u8>, Infallible> {
         let mut module = wasm_encoder::Module::new();
 
         // core

--- a/lib/coredump-encoder/src/lib.rs
+++ b/lib/coredump-encoder/src/lib.rs
@@ -1,22 +1,23 @@
-use std::io::Write;
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+use core::convert::Infallible;
 use wasm_coredump_types as types;
 
-type BoxError = Box<dyn std::error::Error + Sync + Send>;
-
-pub(crate) fn write_unsigned_leb128(buffer: &mut Vec<u8>, n: u64) {
+fn write_unsigned_leb128(buffer: &mut Vec<u8>, n: u64) {
     leb128::write::unsigned(buffer, n).expect("could not write LEB128");
 }
 
 fn write_utf8(buffer: &mut Vec<u8>, v: &str) {
     let bytes = v.as_bytes().to_vec();
     write_unsigned_leb128(buffer, bytes.len() as u64);
-    buffer.write_all(&bytes).unwrap();
+    buffer.extend_from_slice(&bytes);
 }
 
 pub fn encode_coredump_process(
     buffer: &mut Vec<u8>,
     process_info: &types::ProcessInfo,
-) -> Result<(), BoxError> {
+) -> Result<(), Infallible> {
     buffer.push(0x0);
     write_utf8(buffer, &process_info.executable_name);
 
@@ -26,7 +27,7 @@ pub fn encode_coredump_process(
 pub fn encode_coredump_stack(
     buffer: &mut Vec<u8>,
     stack: &types::CoreStack,
-) -> Result<(), BoxError> {
+) -> Result<(), Infallible> {
     // thread-info
     {
         buffer.push(0x0); // version 0

--- a/lib/coredump-types/src/lib.rs
+++ b/lib/coredump-types/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
     pub executable_name: String,


### PR DESCRIPTION
Make wasm-coredump-builder and related crates no_std. Closes #6. [leb128](https://crates.io/crates/leb128) still uses std, though, but that's another story.